### PR TITLE
Add modern package harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.sw?
+.*.sw?
+__pycache__/
+/dist
+/*.egg-info/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Installation
 [Download](https://github.com/bsgworld/bsg-python/archive/master.zip) repository, decompress, install with
 `setup.py install`
 
+Alternatively, use pip:
+
+    pip install git+https://github.com/bsgworld/bsg-python.git
+
+or [Poetry](https://python-poetry.org/) to add a requirement:
+
+    poetry add git+https://github.com/bsgworld/bsg-python.git
+
+
 Usage
 -----
 See [BSG REST API Documentation](https://bsg.world/developers/rest-api/) for complete list of API clients, error codes, result codes etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+  "setuptools",
+  "requests",
+  ]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[metadata]
+version = attr: bsg_restapi.__version__
+
+[options]
+install_requires =
+	requests

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-from distutils.core import setup
-from bsg_restapi import __version__
+from setuptools import setup
 
 setup(
     name='bsg-restapi',
-    version=__version__,
     packages=['bsg_restapi'],
     url='https://github.com/bsgworld/bsg-python',
     license='BSD 2-Clause License',


### PR DESCRIPTION
As per general Python Packaging recommendations:

1. distutils replaced with setuptools
2. Modern build system support through pyproject.toml addition

This allows the package to be built in an isolated environment, and adds modern binary wheel distribution support (not possible with legacy distutils). In turn, this enables specifying the module as a dependency in other projects - just put `git+https://github.com/...` in the `requirements.txt`, no need to mention `requests` explicitly to make it work, and also allows Python Poetry to manage the dependency (something we couldn't do in our project).